### PR TITLE
Link `.luarc.json` with Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,22 @@
         "type": "github"
       }
     },
+    "neodev": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697004367,
+        "narHash": "sha256-sxn2e4GfsHK3s/cAvrAl0NHa5rNSneU/0qVrlKGt9Hw=",
+        "owner": "folke",
+        "repo": "neodev.nvim",
+        "rev": "a4b6e7ca11ff5be2264d5c169fcedd97d8699ec4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "folke",
+        "repo": "neodev.nvim",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1696798496,
@@ -51,6 +67,7 @@
       "inputs": {
         "lualscheck": "lualscheck",
         "mini-nvim": "mini-nvim",
+        "neodev": "neodev",
         "nixpkgs": "nixpkgs",
         "vimhelp": "vimhelp"
       }

--- a/nix/luarc.nix
+++ b/nix/luarc.nix
@@ -1,0 +1,24 @@
+{
+  coreutils,
+  writeTextFile,
+  neodev,
+}: let
+  luarc =
+    (writeTextFile {
+      name = ".luarc.json";
+      text = builtins.toJSON {
+        "workspace.library" = [
+          "./lua"
+          "${neodev}/types/stable"
+          "\${3rd}/luv/library"
+          "\${3rd}/luassert/library"
+        ];
+      };
+    })
+    .overrideAttrs {
+      passthru.link-to-cwd = ''
+        ${coreutils}/bin/ln --force --symbolic ${luarc} .luarc.json
+      '';
+    };
+in
+  luarc

--- a/nix/mkCheck.nix
+++ b/nix/mkCheck.nix
@@ -1,4 +1,7 @@
-{stdenv}: args @ {name, ...}: let
+{
+  stdenv,
+  luarc,
+}: args @ {name, ...}: let
   args' = builtins.removeAttrs args ["name"];
 in
   stdenv.mkDerivation ({
@@ -12,6 +15,7 @@ in
 
       postPatch = ''
         export HOME=$(pwd)
+        ${luarc.link-to-cwd}
       '';
 
       installPhase = ''


### PR DESCRIPTION
This lets `nix develop` set up the `lua-language-server` prerequisites.