### PR TITLE
Skip parenthesis on single-argument string functions in Lua code

### DIFF
--- a/lua/broot/default_directory.lua
+++ b/lua/broot/default_directory.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.git_root()
   -- Directory of the current file.
-  local directory = vim.fn.expand("%:h")
+  local directory = vim.fn.expand "%:h"
   local repo_root
   local job_id = vim.fn.jobstart({ "git", "rev-parse", "--show-toplevel" }, {
     cwd = directory,
@@ -16,16 +16,16 @@ function M.git_root()
     end,
   })
   if job_id == 0 then
-    error("Invalid arguments when running `git rev-parse --show-toplevel`")
+    error "Invalid arguments when running `git rev-parse --show-toplevel`"
   elseif job_id == -1 then
-    error("`git` is not executable")
+    error "`git` is not executable"
   end
   vim.fn.jobwait({ job_id }, -1)
   return repo_root
 end
 
 function M.current_file()
-  return vim.fn.expand("%:h")
+  return vim.fn.expand "%:h"
 end
 
 return M

--- a/lua/broot/init.lua
+++ b/lua/broot/init.lua
@@ -48,7 +48,7 @@ end
 function M._mktemp()
   local path = vim.fn.tempname()
   if path == nil then
-    error("Failed to create tempfile")
+    error "Failed to create tempfile"
   end
   local file = io.open(path, "w")
   if file ~= nil then
@@ -91,7 +91,7 @@ function M.broot(opts)
   -- Create an unlisted `scratch-buffer`.
   local buffer_id = vim.api.nvim_create_buf(false, true)
   if buffer_id == 0 then
-    error("Failed to create buffer")
+    error "Failed to create buffer"
   end
   -- Don't warn when exiting the Broot buffer.
   vim.api.nvim_buf_set_option(buffer_id, "modified", false)
@@ -107,7 +107,7 @@ function M.broot(opts)
     style = "minimal",
   })
   if window_id == 0 then
-    error("Failed to open window")
+    error "Failed to open window"
   end
 
   local cmd_path = M._mktemp()
@@ -139,11 +139,11 @@ function M.broot(opts)
 
   local job_id = vim.fn.termopen(cmd, cmd_opts)
   if job_id == 0 then
-    error("Invalid job arguments")
+    error "Invalid job arguments"
   elseif job_id == -1 then
     error("Broot command is not executable: " .. M.broot_binary)
   end
-  vim.cmd(":startinsert")
+  vim.cmd ":startinsert"
 
   vim.api.nvim_create_augroup("Broot", {})
   vim.api.nvim_create_autocmd("VimResized", {

--- a/scripts/lua/test.lua
+++ b/scripts/lua/test.lua
@@ -1,4 +1,4 @@
-local MiniTest = require("mini.test")
+local MiniTest = require "mini.test"
 
 local M = {}
 

--- a/scripts/mini_test_init.lua
+++ b/scripts/mini_test_init.lua
@@ -2,9 +2,9 @@ vim.opt.statusline = "%t"
 
 -- Add current directory to 'runtimepath' to be able to use 'lua' files
 -- Add 'mini.nvim' to 'runtimepath' to be able to use 'mini.test'
-local mini_nvim = os.getenv("MINI_NVIM")
+local mini_nvim = os.getenv "MINI_NVIM"
 if mini_nvim == nil then
-  error("$MINI_NVIM is not set; are you in the `nix develop` shell?")
+  error "$MINI_NVIM is not set; are you in the `nix develop` shell?"
 end
 local cwd = vim.fn.getcwd()
 vim.opt.runtimepath:append("," .. vim.fn.join({ cwd, cwd .. "/scripts", mini_nvim }, ","))

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,4 +1,4 @@
 column_width = 120
 indent_type = "Spaces"
 indent_width = 2
-call_parentheses = "NoSingleTable"
+call_parentheses = "None"

--- a/tests/test_broot.lua
+++ b/tests/test_broot.lua
@@ -1,10 +1,10 @@
-local MiniTest = require("mini.test")
+local MiniTest = require "mini.test"
 local expect, eq = MiniTest.expect, MiniTest.expect.equality
 
 local T, child = require("test").new_set { module = "broot" }
 
 T["can_open_file"] = function()
-  eq(child.lua_get([[M.broot()]]), vim.NIL)
+  eq(child.lua_get [[M.broot()]], vim.NIL)
   vim.loop.sleep(250)
   child.type_keys(100, "sam", "<CR>")
   vim.loop.sleep(250)
@@ -12,26 +12,26 @@ T["can_open_file"] = function()
 end
 
 T["can_use_directory"] = function()
-  eq(child.lua_get([[M.broot{directory = "flavors"}]]), vim.NIL)
+  eq(child.lua_get [[M.broot{directory = "flavors"}]], vim.NIL)
   vim.loop.sleep(250)
   expect.reference_screenshot(child.get_screenshot())
 end
 
 T["can_use_git_root_directory"] = function()
-  child.lua([[
+  child.lua [[
     M.setup {
       default_directory = require("broot.default_directory").git_root
     }
-  ]])
-  eq(child.lua_get([[M.broot{directory = M.GIT_ROOT}]]), vim.NIL)
+  ]]
+  eq(child.lua_get [[M.broot{directory = M.GIT_ROOT}]], vim.NIL)
   vim.loop.sleep(250)
   child.type_keys(100, " cd", "<CR>")
   vim.loop.sleep(250)
-  eq(child.lua_get([[vim.fn.getcwd()]]), vim.trim(vim.fn.system("git rev-parse --show-toplevel")))
+  eq(child.lua_get [[vim.fn.getcwd()]], vim.trim(vim.fn.system "git rev-parse --show-toplevel"))
 end
 
 T["can_use_extra_args"] = function()
-  eq(child.lua_get([[M.broot{extra_args = {"--cmd", "c/sam"}}]]), vim.NIL)
+  eq(child.lua_get [[M.broot{extra_args = {"--cmd", "c/sam"}}]], vim.NIL)
   vim.loop.sleep(250)
   expect.reference_screenshot(child.get_screenshot())
 end
@@ -39,7 +39,7 @@ end
 T["can_resize"] = function()
   child.o.lines = 35
   child.o.columns = 100
-  eq(child.lua_get([[M.broot()]]), vim.NIL)
+  eq(child.lua_get [[M.broot()]], vim.NIL)
   vim.loop.sleep(250)
 
   child.o.lines = 24

--- a/tests/test_default_directory.lua
+++ b/tests/test_default_directory.lua
@@ -1,18 +1,18 @@
-local MiniTest = require("mini.test")
+local MiniTest = require "mini.test"
 local eq = MiniTest.expect.equality
 
 local T, child = require("test").new_set { module = "broot.default_directory" }
 
 T["git_root"] = function()
-  eq(child.lua_get([[M.git_root()]]), vim.trim(vim.fn.system("git rev-parse --show-toplevel")))
+  eq(child.lua_get [[M.git_root()]], vim.trim(vim.fn.system "git rev-parse --show-toplevel"))
 
   -- In the root directory, we shouldn't have a repo root:
-  child.cmd([[ cd / ]])
-  eq(child.lua_get([[M.git_root()]]), vim.NIL)
+  child.cmd [[ cd / ]]
+  eq(child.lua_get [[M.git_root()]], vim.NIL)
 end
 
 T["current_file"] = function()
-  eq(child.lua_get([[M.current_file()]]), vim.fn.expand("%:h"))
+  eq(child.lua_get [[M.current_file()]], vim.fn.expand "%:h")
 end
 
 return T

--- a/tests/test_user_commands.lua
+++ b/tests/test_user_commands.lua
@@ -1,4 +1,4 @@
-local MiniTest = require("mini.test")
+local MiniTest = require "mini.test"
 local expect = MiniTest.expect
 
 local T, child = require("test").new_set {
@@ -11,13 +11,13 @@ local T, child = require("test").new_set {
 }
 
 T[":Broot"] = function()
-  child.cmd([[Broot]])
+  child.cmd [[Broot]]
   vim.loop.sleep(250)
   expect.reference_screenshot(child.get_screenshot())
 end
 
 T[":Broot directory"] = function()
-  child.cmd([[Broot ./flavors]])
+  child.cmd [[Broot ./flavors]]
   -- child.cmd([[ Broot flavors ]])
   vim.loop.sleep(250)
   expect.reference_screenshot(child.get_screenshot())


### PR DESCRIPTION
This makes the syntax slightly nicer.